### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "exclude-from-classmap": ["/Tests/"]
     },
     "require": {
-        "php": "^7.3|^8.0",
-        "oro/commerce": "4.2.*"
+        "php": "~8.3.0",
+        "oro/commerce": "6.0.*"
     },
     "repositories": {
         "oro": {
@@ -34,10 +34,10 @@
     "require-dev": {
         "phpmd/phpmd": "^2.8",
         "phpro/grumphp": "^1.1.0",
-        "phpspec/phpspec": "^6.1",
-        "phpstan/phpstan": "0.12.91",
+        "phpspec/phpspec": "^7.5",
+        "phpstan/phpstan": "^1.10",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "enlightn/security-checker": "^1.9",
-        "friendsofphp/php-cs-fixer": "^2.18"
+        "friendsofphp/php-cs-fixer": "~3.57.2"
     }
 }

--- a/src/Synolia/Bundle/CreditLineBundle/Entity/CreditLineSettings.php
+++ b/src/Synolia/Bundle/CreditLineBundle/Entity/CreditLineSettings.php
@@ -10,51 +10,23 @@ use Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Entity(repositoryClass="Synolia\Bundle\CreditLineBundle\Entity\Repository\CreditLineSettingsRepository")
- */
+#[ORM\Entity(repositoryClass: \Synolia\Bundle\CreditLineBundle\Entity\Repository\CreditLineSettingsRepository::class)]
 class CreditLineSettings extends Transport
 {
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="credit_line_trans_label",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="transport_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
-     * @Assert\NotBlank
      */
+    #[Assert\NotBlank]
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'credit_line_trans_label', joinColumns: [new ORM\JoinColumn(name: 'transport_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     private $labels;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="credit_line_short_label",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="transport_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
-     * @Assert\NotBlank
      */
+    #[Assert\NotBlank]
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'credit_line_short_label', joinColumns: [new ORM\JoinColumn(name: 'transport_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     private $shortLabels;
 
     /**

--- a/src/Synolia/Bundle/CreditLineBundle/Form/Type/CreditLineSettingsType.php
+++ b/src/Synolia/Bundle/CreditLineBundle/Form/Type/CreditLineSettingsType.php
@@ -52,7 +52,7 @@ class CreditLineSettingsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::BLOCK_PREFIX;
     }


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | yes/no
